### PR TITLE
fix pdf thumbnail generation crash

### DIFF
--- a/GWorkspace/Thumbnailer/ImageThumbnailer/ImageThumbnailer.m
+++ b/GWorkspace/Thumbnailer/ImageThumbnailer/ImageThumbnailer.m
@@ -46,7 +46,17 @@
 - (NSData *)makeThumbnailForPath:(NSString *)path
 {
   CREATE_AUTORELEASE_POOL(arp);
-  NSImage *image = [[NSImage alloc] initWithContentsOfFile: path];
+
+  NSImage *image = [NSImage alloc];
+
+  @try
+    {
+      [image initWithContentsOfFile: path];
+    }
+  @catch (NSException *exception)
+    {
+      NSLog(@"Error while loading image %@: Caught %@: %@", path,  [exception name], [exception reason]);
+    }
 
   if (image && [image isValid])
     {


### PR DESCRIPTION
Hello! GWorkspace is crashing when PDF file thumbnail generation, this PR fixes.

>ffkirill@fr33alexey:~$ GWorkspace 
>2023-12-01 13:59:28.053 fswatcher[88571:88571] register client 2
>2023-12-01 13:59:42.368 ddbd[88573:88573] ddbd started
>2023-12-01 14:00:01.933 GWorkspace[88570:88570] (0) writing to: /home/ffkirill/GNUstep/Library/Thumbnails/thumbnails.plist
>2023-12-01 14:00:01.978 GWorkspace[88570:88577] _makeThumbnails (1): /
>2023-12-01 14:00:01.979 GWorkspace[88570:88577] Last thumbnailer instance, dealloc'ing
>2023-12-01 14:00:26.887 GWorkspace[88570:88570] (0) writing to: /home/ffkirill/GNUstep/Library/Thumbnails/thumbnails.plist
>2023-12-01 14:00:26.889 GWorkspace[88570:88579] _makeThumbnails (1): /media/Images
>2023-12-01 14:00:28.339 GWorkspace[88570:88579] ImageMagick: attempt to perform an operation not allowed by the security policy `PDF' @ error/constitute.c/IsCoderAuthorized/421
GWorkspace: Uncaught exception NSRangeException, reason: Index 0 is out of range 0 (in 'objectAtIndex:')
>2023-12-01 14:00:28.385 ddbd[88573:88573] ddbd: connection became invalid, shutting down
>2023-12-01 14:00:28.389 fswatcher[88571:88571] Connection became invalid
>2023-12-01 14:00:28.389 fswatcher[88571:88571] No more clients, shutting down.
